### PR TITLE
feat: kovaa

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "arrowParens": "always"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mcint",
       "version": "0.0.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "dayjs": "^1.11.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -22,6 +23,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "prettier": "^3.3.3",
         "stylelint": "^16.6.1",
         "stylelint-config-recommended": "^14.0.0",
         "typescript": "^5.2.2",
@@ -1769,6 +1771,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3233,6 +3241,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "dayjs": "^1.11.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -24,6 +25,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "prettier": "^3.3.3",
     "stylelint": "^16.6.1",
     "stylelint-config-recommended": "^14.0.0",
     "typescript": "^5.2.2",

--- a/src/actions/getItems.ts
+++ b/src/actions/getItems.ts
@@ -1,3 +1,4 @@
+import { Item } from "~/types";
 import { fakeFetch } from "../utils/fakeFetch";
 import { getRandomItems } from "../utils/getRandomItems";
 
@@ -9,17 +10,14 @@ let requestCount = 0;
 /*  to avoid setting up a real backend, */
 /*  details are not important here */
 /* ========================================== */
-export const getDocumentChildItems = ({ id }: { id: string }) => {
+
+export type GetItemsParams = { id: string };
+
+export const getDocumentChildItems = ({ id }: GetItemsParams): Promise<Item[]> => {
   if (++requestCount > MAX_REQUEST_COUNT) {
     console.log(">>> Possible infinite loop detected!");
     throw new Error("Possible infinite loop");
   }
 
-  return fakeFetch(() => {
-    if (Math.random() < 0.6) {
-      throw new Error("Random error");
-    }
-
-    return getRandomItems();
-  }, `getChildItems for item ${id}`);
+  return fakeFetch(getRandomItems, `getChildItems for item ${id}`, true);
 };

--- a/src/actions/getItems.ts
+++ b/src/actions/getItems.ts
@@ -9,11 +9,17 @@ let requestCount = 0;
 /*  to avoid setting up a real backend, */
 /*  details are not important here */
 /* ========================================== */
-export const getDocumentChildItems = (id: string) => {
+export const getDocumentChildItems = ({ id }: { id: string }) => {
   if (++requestCount > MAX_REQUEST_COUNT) {
     console.log(">>> Possible infinite loop detected!");
-    return Promise.resolve(null);
+    throw new Error("Possible infinite loop");
   }
 
-  return fakeFetch(getRandomItems, `getChildItems for item ${id}`);
+  return fakeFetch(() => {
+    if (Math.random() < 0.6) {
+      throw new Error("Random error");
+    }
+
+    return getRandomItems();
+  }, `getChildItems for item ${id}`);
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,7 +4,6 @@ function App() {
   return (
     <div className="layout">
       <Sidebar />
-      <div className="background" />
     </div>
   );
 }

--- a/src/components/Icon/Icon.css
+++ b/src/components/Icon/Icon.css
@@ -1,0 +1,51 @@
+.icon,
+.emoji {
+  width: 18px;
+  height: 18px;
+}
+
+.icon {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #d0d0d0;
+  border-radius: 5px;
+}
+
+.icon svg {
+  display: block;
+}
+
+.icon._error {
+  background: #ff6262;
+}
+
+.icon._loading svg {
+  animation: spin 2s linear infinite;
+}
+
+.icon._wobble {
+  animation: wobble 0.5s 1;
+}
+
+@keyframes wobble {
+  25% {
+    transform: rotate(15deg);
+  }
+  50% {
+    transform: rotate(-30deg);
+  }
+  75% {
+    transform: rotate(5deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import cn from "classnames";
+
+import { Icon as IconUI } from "~/ui/Icons/Icons";
+import { getIconType } from "./helpers";
+
+import "./Icon.css";
+
+type Props = {
+  isLoading: boolean;
+  isOpen: boolean;
+  emoji: string;
+  hasError: boolean;
+  hasHover: boolean;
+  animate: boolean;
+  onAnimationEnd?: () => void;
+};
+
+export const Icon = ({
+  isLoading = true,
+  isOpen,
+  hasError,
+  emoji,
+  hasHover,
+  onAnimationEnd,
+  animate,
+}: Props) => {
+  const error = hasError && !isLoading;
+  const loading = isLoading && isOpen;
+  const iconType = getIconType({ loading, isOpen, error });
+  const size = error ? 13 : 15;
+  const color = error ? "#fff" : "#000";
+
+  if (hasHover || (isLoading && isOpen) || hasError) {
+    return (
+      <div
+        className={cn("icon", {
+          _error: error,
+          _loading: loading,
+          _wobble: animate,
+        })}
+        onAnimationEnd={onAnimationEnd}
+      >
+        <IconUI type={iconType} size={size} color={color} />
+      </div>
+    );
+  }
+
+  return <div className="emoji">{emoji}</div>;
+};

--- a/src/components/Icon/helpers.ts
+++ b/src/components/Icon/helpers.ts
@@ -1,0 +1,23 @@
+import { IconsType } from "~/ui/Icons/Icons";
+
+type Props = {
+  loading: boolean;
+  isOpen: boolean;
+  error: boolean;
+};
+
+export const getIconType = ({ loading, isOpen, error }: Props): IconsType => {
+  if (loading) {
+    return "loader";
+  }
+
+  if (error) {
+    return "alert";
+  }
+
+  if (isOpen) {
+    return "chevronDown";
+  }
+
+  return "chevronRight";
+};

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -1,0 +1,42 @@
+button {
+  border: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  overflow: visible;
+
+  background: transparent;
+
+  /* inherit font & color from ancestor */
+  color: inherit;
+  font: inherit;
+
+  /* Normalize `line-height`. Cannot be changed from `normal` in Firefox 4+. */
+  line-height: normal;
+
+  /* Corrects font smoothing for webkit */
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
+
+  /* Corrects inability to style clickable `input` types in iOS */
+  -webkit-appearance: none;
+  width: 100%;
+  text-align: left;
+}
+
+.item {
+  display: flex;
+  position: relative;
+  cursor: pointer;
+  padding: 10px 15px;
+  gap: 5px;
+}
+
+.item:hover {
+  background-color: #e7e7e7;
+  border-radius: 8px;
+}
+
+.items {
+  margin-left: 15px;
+}

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -29,7 +29,7 @@ button {
   position: relative;
   cursor: pointer;
   padding: 10px 15px;
-  gap: 5px;
+  gap: 8px;
 }
 
 .item:hover {
@@ -37,6 +37,14 @@ button {
   border-radius: 8px;
 }
 
+.title {
+  border-bottom: 1px solid transparent;
+}
+
+.item:hover .title {
+  border-color:rgb(0 0 0 / 35%);
+}
+
 .items {
-  margin-left: 15px;
+  margin-left: 14px;
 }

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -4,7 +4,7 @@ import "./ListItem.css";
 // here is the ts type of the data
 import { Item } from "../types";
 // here are the icons if you need them
-import { getDocumentChildItems } from "~/actions/getItems";
+import { getDocumentChildItems, GetItemsParams } from "~/actions/getItems";
 import useResolver from "~/hooks/useResolver";
 import { MapCache } from "~/resolvers/cacheImpl";
 
@@ -56,10 +56,9 @@ export const ListItem = ({ item }: Props) => {
 
     setIconError(true);
     setAnimateIcon(true);
-    itemsCache.set(item.id, true);
   }, [error, isOpen]);
 
-  // override css rules to control the state of the icon from a single location
+  // override css rules to control the state of the icon from a single location (<Icon> component)
   const mouseEnterHandler = () => {
     setHasHover(true);
   };
@@ -68,7 +67,7 @@ export const ListItem = ({ item }: Props) => {
     setHasHover(false);
   };
 
-  const onAnimationEnd = () => {
+  const onIconAnimationEnd = () => {
     setAnimateIcon(false);
   };
 
@@ -86,7 +85,7 @@ export const ListItem = ({ item }: Props) => {
           emoji={item.emoji}
           hasError={showIconError}
           hasHover={hasHover}
-          onAnimationEnd={onAnimationEnd}
+          onAnimationEnd={onIconAnimationEnd}
           animate={animateIcon}
         />
         <div className="title">{item.title}</div>
@@ -101,16 +100,13 @@ export const ListItem = ({ item }: Props) => {
   );
 };
 
-type FetchParams = {
-  id: string;
-};
 
 type FetchResult = Item[];
 
-type ResolverParams = FetchParams & { title: string };
+type ResolverParams = GetItemsParams & { title: string };
 
 const useResolveItems = ({ id, title }: ResolverParams) => {
-  return useResolver<FetchParams, FetchResult>(getDocumentChildItems, {
+  return useResolver<GetItemsParams, FetchResult>(getDocumentChildItems, {
     requestParams: { id },
     queryParams: { prefetch: true },
     cacheOptions: { key: `${id}_${title}` },

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,23 +1,118 @@
-import React from "react";
-
+import React, { useCallback, useEffect, useState } from "react";
 // here you can add styles
 import "./ListItem.css";
 // here is the ts type of the data
 import { Item } from "../types";
 // here are the icons if you need them
-import { ChevronRight, ChevronDown } from "react-feather";
-// here is the method to get the data
-// const result = await getDocumentChildItems()
-import { getDocumentChildItems } from "../actions/getItems";
+import { getDocumentChildItems } from "~/actions/getItems";
+import useResolver from "~/hooks/useResolver";
+import { MapCache } from "~/resolvers/cacheImpl";
 
+import { Icon } from "./Icon/Icon";
+
+// saving the state of open menu items
+const itemsCache = new MapCache<boolean>();
 interface Props {
   item: Item;
 }
 
 export const ListItem = ({ item }: Props) => {
+  const [hasHover, setHasHover] = useState(false);
+  const [showIconError, setIconError] = useState(false);
+  const [animateIcon, setAnimateIcon] = useState(false);
+  const [isOpen, setIsOpen] = useState(itemsCache.get(item.id) || false);
+  const { refetch, isLoading, data, error } = useResolveItems({
+    id: item.id,
+    title: item.title,
+  });
+
+  const clickHandler = useCallback(() => {
+    if (error) {
+      // set open state for further data display
+      setIsOpen(true);
+      refetch();
+      return;
+    }
+
+    const currentState = !isOpen;
+    setIsOpen(currentState);
+  }, [error, isOpen]);
+
+  // awaits for data flow
+  useEffect(() => {
+    if (!isOpen || !data) {
+      return;
+    }
+
+    setIconError(false);
+    itemsCache.set(item.id, true);
+  }, [data, isOpen]);
+
+  // awaits for error flow
+  useEffect(() => {
+    if (!error || !isOpen) {
+      return;
+    }
+
+    setIconError(true);
+    setAnimateIcon(true);
+    itemsCache.set(item.id, true);
+  }, [error, isOpen]);
+
+  // override css rules to control the state of the icon from a single location
+  const mouseEnterHandler = () => {
+    setHasHover(true);
+  };
+
+  const mouseLeaveHandler = () => {
+    setHasHover(false);
+  };
+
+  const onAnimationEnd = () => {
+    setAnimateIcon(false);
+  };
+
   return (
-    <div>
-      {item.emoji} {item.title}
-    </div>
+    <>
+      <button
+        className="item"
+        onClick={clickHandler}
+        onMouseEnter={mouseEnterHandler}
+        onMouseLeave={mouseLeaveHandler}
+      >
+        <Icon
+          isLoading={isLoading}
+          isOpen={isOpen}
+          emoji={item.emoji}
+          hasError={showIconError}
+          hasHover={hasHover}
+          onAnimationEnd={onAnimationEnd}
+          animate={animateIcon}
+        />
+        <div className="title">{item.title}</div>
+      </button>
+
+      <div className="items">
+        {isOpen
+          ? data?.map((item) => <ListItem item={item} key={item.id} />)
+          : null}
+      </div>
+    </>
   );
+};
+
+type FetchParams = {
+  id: string;
+};
+
+type FetchResult = Item[];
+
+type ResolverParams = FetchParams & { title: string };
+
+const useResolveItems = ({ id, title }: ResolverParams) => {
+  return useResolver<FetchParams, FetchResult>(getDocumentChildItems, {
+    requestParams: { id },
+    queryParams: { prefetch: true },
+    cacheOptions: { key: `${id}_${title}` },
+  });
 };

--- a/src/hooks/useResolver.ts
+++ b/src/hooks/useResolver.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+import resolverImpl, {
+  ResolverOptions,
+  ResolverParams,
+} from "~/resolvers/resolverImpl";
+
+type Return<Result> = {
+  isLoading: boolean;
+  data: Result | undefined;
+  error: Error | undefined;
+  refetch: () => void;
+};
+
+type QueryParams = {
+  queryParams: { prefetch: boolean };
+};
+
+type Options<Params extends ResolverParams> = ResolverOptions<Params> &
+  QueryParams;
+
+const useResolver = <Params extends ResolverParams, Result>(
+  resolver: (args: Params) => Promise<Result>,
+  {
+    requestParams: params,
+    cacheOptions,
+    queryParams: { prefetch },
+  }: Options<Params>,
+): Return<Result> => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [needFetch, setNeedFetch] = useState(prefetch);
+  const [data, setData] = useState<Result | undefined>(undefined);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  const refetch = () => {
+    setNeedFetch(true);
+  };
+
+  useEffect(() => {
+    if (!needFetch) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+
+    async function fetch() {
+      const { result, error } = await resolverImpl<Params, Result>(resolver, {
+        requestParams: params,
+        cacheOptions,
+      });
+
+      setData(result);
+      setError(error);
+      setIsLoading(false);
+      setNeedFetch(false);
+    }
+
+    fetch();
+  }, [needFetch]);
+
+  return { isLoading, data, error, refetch };
+};
+
+export default useResolver;

--- a/src/resolvers/cacheImpl.ts
+++ b/src/resolvers/cacheImpl.ts
@@ -1,0 +1,37 @@
+type Level = "request" | "session"; // | '???' | 'no-cache'
+
+export type CacheOptions = {
+  level?: Level;
+  key?: string;
+  expiration?: number;
+};
+
+export class MapCache<Value> {
+  private _map: Map<string, Value>;
+
+  constructor() {
+    this._map = new Map();
+  }
+
+  public set(key: string, value: Value) {
+    this._map.set(key, value);
+  }
+
+  public get(key: string) {
+    if (this._map.has(key)) {
+      return this._map.get(key);
+    }
+  }
+
+  public has(key: string) {
+    return this._map.has(key);
+  }
+
+  public delete(key: string) {
+    return this._map.delete(key);
+  }
+
+  public clear() {
+    return this._map.clear();
+  }
+}

--- a/src/resolvers/resolverImpl.ts
+++ b/src/resolvers/resolverImpl.ts
@@ -1,0 +1,60 @@
+import { CacheOptions, MapCache } from "./cacheImpl";
+
+export type ResolverParams = { [key: string]: string };
+
+export type ResolverOptions<Params extends ResolverParams> = {
+  requestParams: Params;
+  cacheOptions?: CacheOptions;
+};
+
+const generateKeyFromParams = (params: ResolverParams) => {
+  let string = "";
+
+  for (const key in params) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      const value = params[key];
+
+      string += `_key_${value}`;
+    }
+  }
+
+  return string;
+};
+
+const cache = new MapCache();
+
+type ResolverResult<Result> = {
+  result?: Result;
+  error?: Error;
+};
+
+const resolverImpl = async <Params extends ResolverParams, Result>(
+  resolver: (args: Params) => Promise<Result>,
+  { requestParams, cacheOptions }: ResolverOptions<Params>,
+): Promise<ResolverResult<Result>> => {
+  let result;
+  let error;
+
+  const key = cacheOptions?.key
+    ? `${resolver.name}_${cacheOptions?.key}`
+    : `${resolver.name}_${generateKeyFromParams(requestParams)}`;
+
+  if (cache.has(key)) {
+    return { result: cache.get(key) as Result };
+  }
+
+  try {
+    result = await resolver(requestParams);
+    cache.set(key, result);
+  } catch (e) {
+    if (typeof e === "string") {
+      error = new Error(e);
+    } else if (e instanceof Error) {
+      error = new Error(e.message);
+    }
+  }
+
+  return { result, error };
+};
+
+export default resolverImpl;

--- a/src/resolvers/resolverImpl.ts
+++ b/src/resolvers/resolverImpl.ts
@@ -11,7 +11,7 @@ const generateKeyFromParams = (params: ResolverParams) => {
   let string = "";
 
   for (const key in params) {
-    if (Object.prototype.hasOwnProperty.call(object, key)) {
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
       const value = params[key];
 
       string += `_key_${value}`;
@@ -47,11 +47,16 @@ const resolverImpl = async <Params extends ResolverParams, Result>(
     result = await resolver(requestParams);
     cache.set(key, result);
   } catch (e) {
+    let message
     if (typeof e === "string") {
+      message = e;
       error = new Error(e);
     } else if (e instanceof Error) {
+      message = e.message
       error = new Error(e.message);
     }
+
+    console.error(`Resolver ${resolver.name} failed with message "${message}"`, { requestParams }, { error: e });
   }
 
   return { result, error };

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,8 +19,8 @@
   position: absolute;
   left: 0;
   top: 0;
+  bottom: 0;
   width: 400px;
-  height: 100%;
   overflow-y: scroll;
   background-color: #f7f7f5;
   padding: 32px calc(32px - 12px);

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,16 +4,8 @@
 
 .layout {
   min-height: 100vh;
-  display: flex;
-}
-
-.background {
-  width: 100%;
   background-image: url("assets/background.jpg");
-  background-size: cover;
-  background-repeat: no-repeat;
 }
-
 .branding {
   display: flex;
   width: fit-content;
@@ -24,11 +16,16 @@
 }
 
 .sidebar {
-  flex-grow: 1;
-  flex-shrink: 0;
+  position: absolute;
+  left: 0;
+  top: 0;
   width: 400px;
+  height: 100%;
+  overflow-y: scroll;
   background-color: #f7f7f5;
   padding: 32px calc(32px - 12px);
+  box-shadow: 5px 0px 20px rgb(0 0 0 / 32%);
+  z-index: 10;
 }
 
 .sidebarSectionTitle {

--- a/src/ui/Icons/Icons.tsx
+++ b/src/ui/Icons/Icons.tsx
@@ -8,6 +8,7 @@ const icons = {
   loader: Loader,
   alert: XCircle,
 };
+
 export type IconsType = keyof typeof icons;
 
 export const Icon = ({

--- a/src/ui/Icons/Icons.tsx
+++ b/src/ui/Icons/Icons.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { ChevronRight, ChevronDown, Loader, XCircle } from "react-feather";
+
+const icons = {
+  chevronRight: ChevronRight,
+  chevronDown: ChevronDown,
+  loader: Loader,
+  alert: XCircle,
+};
+export type IconsType = keyof typeof icons;
+
+export const Icon = ({
+  type,
+  size = 24,
+  color,
+}: {
+  type: IconsType;
+  size?: number;
+  color?: string;
+}) => {
+  if (!type) {
+    return null;
+  }
+
+  const Component = icons[type];
+
+  return <Component size={size} color={color} />;
+};

--- a/src/utils/fakeFetch.ts
+++ b/src/utils/fakeFetch.ts
@@ -5,7 +5,7 @@
 /* ========================================== */
 export const fakeFetch = <ReturnType>(
   callback: () => ReturnType,
-  resource: string
+  resource: string,
 ): Promise<ReturnType> => {
   console.log(`>>> called - ${resource}`);
 

--- a/src/utils/fakeFetch.ts
+++ b/src/utils/fakeFetch.ts
@@ -3,19 +3,34 @@
 /*  setting up a real backend */
 /*  details are not important here */
 /* ========================================== */
+const getRandomDelay = (min: number, max: number) => {
+  return Math.random() * (max - min) + min;
+}
+
+const getRandomError = (probability: number) => {
+  return (Math.random() < probability);
+}
+
 export const fakeFetch = <ReturnType>(
   callback: () => ReturnType,
   resource: string,
+  withFakeError?: boolean
 ): Promise<ReturnType> => {
+  const start = Date.now();
   console.log(`>>> called - ${resource}`);
 
-  return new Promise((resolve) => {
-    const randomDelayMs = Math.floor(Math.random() * 1000 * 2);
+  return new Promise((resolve, reject) => {
+    const randomDelayMs = getRandomDelay(300, 1000);
     const result = callback();
 
     setTimeout(() => {
+      if (withFakeError && getRandomError(0.4)) {
+        reject(new Error("Random error"));
+      }
+
       resolve(result);
-      console.log(`>>> completed - ${resource}`, { result });
+
+      console.log(`>>> completed - ${resource}`, { result }, `for ${Date.now() - start}ms`);
     }, randomDelayMs);
   });
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import path from "path";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
I wasn't satisfied with the result on the call, so I tweaked the code to the minimum state that suits me. It is unlikely that it could be done on a call, but I would develop a similar application in this direction

- fixed a bug that prevented me from implementing prefetch on a call (lost `isOpen` in rendering),
- add caching of requests by key to reduce the number of requests,
- added global resolver implementation wrapped in caching (`resolverImpl`), could be used for other requests in the application,
- implementation of a global hook for the current state of the query (`useResolver`) similar to `react-query`,
- implemented saving the state of open menu items,
- animation of request state in icon (load/error),
- implemented a random error in `fakeFetch` for demonstration purposes,
- cleaned up the configs a bit,

what direction I would move on next:
- deduplication of requests in resolver so that the same request can be used in different components, if necessary,
- A state manager to store the state of items (`isLoading`, `error`, `isOpen`, etc). We could get rid of re-rendering when retrieving data, as now it's stacked in the component's state and twitched three times (`mount`, `startloading`, `finishLoading`),
- tests and storybook